### PR TITLE
ログアウトに関するテストの実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  skip_before_action :verify_authenticity_token
+  # skip_before_action :verify_authenticity_token
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,4 @@ class User < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 14 }
-  validates :email, presence: true
-  validates :password, presence: true
 end

--- a/db/migrate/20201122145602_add_trackable_to_users.rb
+++ b/db/migrate/20201122145602_add_trackable_to_users.rb
@@ -1,6 +1,6 @@
 class AddTrackableToUsers < ActiveRecord::Migration[6.0]
   def change
-    change_table :users do |t|
+    change_table :users, bulk: true do |t|
       ## Trackable
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -78,4 +78,41 @@ RSpec.describe "Api::V1::Auth::Sesseions", type: :request do
       end
     end
   end
+
+  describe "DELETE api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    context "ログアウトに必要な情報が送信された時" do
+      let(:user) { create(:user) }
+      let(:headers) { user.create_new_auth_token }
+
+      it "ログアウトに成功する" do
+        subject
+
+        expect(user.reload.tokens).to be_blank
+
+        header = response.header
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(header["uid"]).to be_blank
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ログアウトに必要な情報が送信されていない時" do
+      let(:user) { create(:user) }
+      let!(:tokens) { user.create_new_auth_token }
+      let(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
+
+      it "ログアウトに失敗する" do
+        subject
+
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

- rubocop のエラー回避のための記述をmigrationファイルに追加
- User_model の email, password の validation を削除
- sign_out に関するテストを実装