### PR TITLE
マイページに関するコントローラー、テストを追加

### DIFF
--- a/app/controllers/api/v1/currents_controller.rb
+++ b/app/controllers/api/v1/currents_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class CurrentsController < BaseApiController
+      before_action :authenticate_user!, only: [:index]
+
+      def index
+        articles = current_user.articles.published.order(updated_at: :desc)
+        render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
         resources :drafts, only: [:index, :show]
       end
       resources :articles
+      resources :currents, path: "current/articles", only: [:index]
     end
   end
 end

--- a/spec/requests/api/v1/currents_request_spec.rb
+++ b/spec/requests/api/v1/currents_request_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Currents", type: :request do
+  describe "GET /current/articles" do
+    subject { get(api_v1_currents_path, headers: headers) }
+
+    context "マイページにアクセスし" do
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
+
+      context "自分の公開記事が存在する時" do
+        let!(:article1) { create(:article, status: :published, user: current_user) }
+        let!(:article2) { create(:article, status: :published) }
+        let!(:article3) { create(:article, status: :draft, user: current_user) }
+
+        it "自分の公開記事の一覧が取得出来る" do
+          subject
+
+          res = JSON.parse(response.body)
+          expect(res.length).to eq(1)
+          expect(response.status).to eq(200)
+          expect(res[0]["status"]).to eq "published"
+          expect(res[0].keys).to eq ["id", "title", "updated_at", "status", "user"]
+          expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- rails g コマンドにて currents_controllerを生成後、index へ処理を追加
- currents のルーティングを path を指定して追加
- currents のテストを実装